### PR TITLE
libmctp changes to support NVMe querying over SMBus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,25 +3,24 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 add_definitions(-DMCTP_LOG_STDERR)
 add_definitions(-DMCTP_FILEIO)
 
-add_library(libmctp STATIC alloc.c core.c libmctp.h serial.c smbus.c)
+add_library(mctp STATIC alloc.c core.c libmctp.h serial.c smbus.c)
 
-target_include_directories(libmctp
+target_include_directories(mctp
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                                  $<INSTALL_INTERFACE:include/libmctp)
-target_link_libraries(libmctp PUBLIC i2c)
+                                  $<INSTALL_INTERFACE:include/mctp)
+target_link_libraries(mctp PUBLIC i2c)
 
 enable_testing()
 
 add_executable(mctp-in-test tests/mctp-in.c)
-target_link_libraries(mctp-in-test libmctp)
+target_link_libraries(mctp-in-test mctp)
 
 add_executable(mctp-pipe-test tests/mctp-pipe.c)
-target_link_libraries(mctp-pipe-test libmctp)
+target_link_libraries(mctp-pipe-test mctp)
 
 add_executable(mctp-smbus-test tests/mctp-smbus.c crc32c.c)
-target_link_libraries(mctp-smbus-test libmctp)
+target_link_libraries(mctp-smbus-test mctp i2c)
 install(TARGETS mctp-smbus-test DESTINATION bin)
 
-install(TARGETS libmctp DESTINATION lib)
-install(FILES libmctp.h libmctp-smbus.h libmctp-serial.h DESTINATION
-       include/libmctp)
+install(TARGETS mctp DESTINATION lib)
+install(FILES libmctp.h libmctp-smbus.h libmctp-serial.h nvme-mi.h DESTINATION include/mctp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 add_definitions(-DMCTP_LOG_STDERR)
 add_definitions(-DMCTP_FILEIO)
 
-add_library(mctp STATIC alloc.c core.c libmctp.h serial.c smbus.c)
+add_library(mctp STATIC alloc.c core.c libmctp.h serial.c smbus.c crc32c.c)
 
 target_include_directories(mctp
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -23,4 +23,4 @@ target_link_libraries(mctp-smbus-test mctp i2c)
 install(TARGETS mctp-smbus-test DESTINATION bin)
 
 install(TARGETS mctp DESTINATION lib)
-install(FILES libmctp.h libmctp-smbus.h libmctp-serial.h nvme-mi.h DESTINATION include/mctp)
+install(FILES libmctp.h libmctp-smbus.h libmctp-serial.h nvme-mi.h crc32c.h DESTINATION include/mctp)

--- a/core.c
+++ b/core.c
@@ -366,6 +366,7 @@ int mctp_message_tx(struct mctp *mctp, mctp_eid_t eid,
 
 		pkt = mctp_pktbuf_alloc(pkt_len + sizeof(*hdr));
 		hdr = mctp_pktbuf_hdr(pkt);
+		pkt->next = NULL;
 
 		/* todo: tags */
 		hdr->ver = bus->binding->version & 0xf;

--- a/crc32c.h
+++ b/crc32c.h
@@ -1,9 +1,17 @@
 #ifndef CRC32C_H
 #define CRC32C_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
 uint32_t crc32c(uint8_t *buf, int len);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* CRC32C_H */

--- a/libmctp-serial.h
+++ b/libmctp-serial.h
@@ -3,6 +3,11 @@
 #ifndef _LIBMCTP_SERIAL_H
 #define _LIBMCTP_SERIAL_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "libmctp.h"
 
 struct mctp_binding_serial;
@@ -16,4 +21,7 @@ int mctp_serial_open_path(struct mctp_binding_serial *serial,
 		const char *path);
 void mctp_serial_open_fd(struct mctp_binding_serial *serial, int fd);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _LIBMCTP_SERIAL_H */

--- a/libmctp-smbus.h
+++ b/libmctp-smbus.h
@@ -7,38 +7,22 @@
 extern "C"
 {
 #endif
-#include <i2c/smbus.h>
-#include <linux/i2c-dev.h>
+
 #include "libmctp.h"
 
-	struct mctp_binding_smbus
-	{
-		struct mctp_binding binding;
-		struct mctp *mctp;
-		int out_fd;
-		int in_fd;
+struct mctp_binding_smbus;
 
-		unsigned long bus_id;
-
-		/* receive buffer */
-		uint8_t rxbuf[1024];
-		struct mctp_pktbuf *rx_pkt;
-
-		/* temporary transmit buffer */
-		uint8_t txbuf[256];
-	};
-
-	struct mctp_binding_smbus *mctp_smbus_init(void);
-	int mctp_smbus_get_out_fd(struct mctp_binding_smbus *smbus);
-	int mctp_smbus_get_in_fd(struct mctp_binding_smbus *smbus);
-	void mctp_smbus_register_bus(struct mctp_binding_smbus *smbus,
-								 struct mctp *mctp, mctp_eid_t eid);
-	int mctp_smbus_read(struct mctp_binding_smbus *smbus);
-	int mctp_smbus_open_bus(struct mctp_binding_smbus *smbus, int out_bus_num,
-							int root_bus_num);
-	int mctp_smbus_open_root_bus(struct mctp_binding_smbus *smbus,
-                             int root_bus_num);
-	int mctp_smbus_open_out_bus(struct mctp_binding_smbus *smbus, int out_bus_num);
+struct mctp_binding_smbus *mctp_smbus_init(void);
+int mctp_smbus_get_out_fd(struct mctp_binding_smbus *smbus);
+int mctp_smbus_get_in_fd(struct mctp_binding_smbus *smbus);
+void mctp_smbus_register_bus(struct mctp_binding_smbus *smbus,
+							 struct mctp *mctp, mctp_eid_t eid);
+int mctp_smbus_read(struct mctp_binding_smbus *smbus);
+int mctp_smbus_open_bus(struct mctp_binding_smbus *smbus, int out_bus_num,
+						int root_bus_num);
+int mctp_smbus_open_root_bus(struct mctp_binding_smbus *smbus,
+                          int root_bus_num);
+int mctp_smbus_open_out_bus(struct mctp_binding_smbus *smbus, int out_bus_num);
 
 #ifdef __cplusplus
 }

--- a/libmctp-smbus.h
+++ b/libmctp-smbus.h
@@ -3,16 +3,44 @@
 #ifndef _LIBMCTP_SMBUS_H
 #define _LIBMCTP_SMBUS_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include <i2c/smbus.h>
+#include <linux/i2c-dev.h>
 #include "libmctp.h"
 
-struct mctp_binding_smbus;
+	struct mctp_binding_smbus
+	{
+		struct mctp_binding binding;
+		struct mctp *mctp;
+		int out_fd;
+		int in_fd;
 
-struct mctp_binding_smbus *mctp_smbus_init(void);
-int mctp_smbus_get_out_fd(struct mctp_binding_smbus *smbus);
-int mctp_smbus_get_in_fd(struct mctp_binding_smbus *smbus);
-void mctp_smbus_register_bus(struct mctp_binding_smbus *smbus,
-	             struct mctp *mctp, mctp_eid_t eid);
-int mctp_smbus_read(struct mctp_binding_smbus *smbus);
-int mctp_smbus_open_bus(struct mctp_binding_smbus *smbus, int out_bus_num,
-	        int root_bus_num);
+		unsigned long bus_id;
+
+		/* receive buffer */
+		uint8_t rxbuf[1024];
+		struct mctp_pktbuf *rx_pkt;
+
+		/* temporary transmit buffer */
+		uint8_t txbuf[256];
+	};
+
+	struct mctp_binding_smbus *mctp_smbus_init(void);
+	int mctp_smbus_get_out_fd(struct mctp_binding_smbus *smbus);
+	int mctp_smbus_get_in_fd(struct mctp_binding_smbus *smbus);
+	void mctp_smbus_register_bus(struct mctp_binding_smbus *smbus,
+								 struct mctp *mctp, mctp_eid_t eid);
+	int mctp_smbus_read(struct mctp_binding_smbus *smbus);
+	int mctp_smbus_open_bus(struct mctp_binding_smbus *smbus, int out_bus_num,
+							int root_bus_num);
+	int mctp_smbus_open_root_bus(int *in_fd,
+                             int root_bus_num);
+	int mctp_smbus_open_out_bus(struct mctp_binding_smbus *smbus, int out_bus_num);
+
+#ifdef __cplusplus
+}
+#endif
 #endif /* _LIBMCTP_SMBUS_H */

--- a/libmctp-smbus.h
+++ b/libmctp-smbus.h
@@ -36,7 +36,7 @@ extern "C"
 	int mctp_smbus_read(struct mctp_binding_smbus *smbus);
 	int mctp_smbus_open_bus(struct mctp_binding_smbus *smbus, int out_bus_num,
 							int root_bus_num);
-	int mctp_smbus_open_root_bus(int *in_fd,
+	int mctp_smbus_open_root_bus(struct mctp_binding_smbus *smbus,
                              int root_bus_num);
 	int mctp_smbus_open_out_bus(struct mctp_binding_smbus *smbus, int out_bus_num);
 

--- a/libmctp.h
+++ b/libmctp.h
@@ -3,6 +3,11 @@
 #ifndef _LIBMCTP_H
 #define _LIBMCTP_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdint.h>
 
 typedef uint8_t mctp_eid_t;
@@ -129,5 +134,7 @@ void mctp_set_alloc_ops(void *(*alloc)(size_t),
 		void (*free)(void *),
 		void *(realloc)(void *, size_t));
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _LIBMCTP_H */

--- a/nvme-mi.h
+++ b/nvme-mi.h
@@ -3,6 +3,11 @@
 #ifndef _NVMEMI_H
 #define _NVMEMI_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -88,5 +93,8 @@ struct nvme_mi_controller_health {
         uint16_t composite_controller_status;
 };
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _NVMEMI_H */

--- a/smbus.c
+++ b/smbus.c
@@ -185,7 +185,7 @@ int mctp_smbus_open_out_bus(struct mctp_binding_smbus *smbus, int out_bus_num)
         return 0;
 }
 
-int mctp_smbus_open_root_bus(int *in_fd,
+int mctp_smbus_open_root_bus(struct mctp_binding_smbus *smbus,
                              int root_bus_num)
 {
         char filename[60];
@@ -204,8 +204,8 @@ int mctp_smbus_open_root_bus(int *in_fd,
             filename, size, "/sys/bus/i2c/devices/i2c-%d/%d-%04x/slave-mqueue",
             root_bus_num, root_bus_num, (address_7_bit << 8) + address_7_bit);
 
-        *in_fd = open(filename, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-        if (*in_fd < 0)
+        smbus->in_fd = open(filename, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+        if (smbus->in_fd < 0)
         {
                 // Device doesn't exist.  Create it.
                 filename_size = sizeof(filename);
@@ -240,9 +240,9 @@ int mctp_smbus_open_root_bus(int *in_fd,
                          root_bus_num, root_bus_num,
                          (address_7_bit << 8) + address_7_bit);
 
-                *in_fd =
+                smbus->in_fd =
                     open(filename, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-                if (*in_fd < 0)
+                if (smbus->in_fd < 0)
                 {
                         mctp_prerr("can't open mqueue device on %s: %m",
                                    filename);

--- a/smbus.c
+++ b/smbus.c
@@ -12,12 +12,29 @@
 
 #define pr_fmt(x) "smbus: " x
 
+#include <i2c/smbus.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
 #include <sys/ioctl.h>
 
 #include "libmctp-alloc.h"
 #include "libmctp-log.h"
 #include "libmctp-smbus.h"
 #include "libmctp.h"
+
+struct mctp_binding_smbus
+{
+	struct mctp_binding binding;
+	struct mctp *mctp;
+	int out_fd;
+	int in_fd;
+	unsigned long bus_id;
+	/* receive buffer */
+	uint8_t rxbuf[1024];
+	struct mctp_pktbuf *rx_pkt;
+	/* temporary transmit buffer */
+	uint8_t txbuf[256];
+};
 
 #ifndef container_of
 #define container_of(ptr, type, member)                                        \


### PR DESCRIPTION
These changes are necessary for the dbus-sensors to send query MCTP requests over
SMBus to the NVMe devices